### PR TITLE
Ignore non php files in resources/lang folders

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -44,6 +44,10 @@ class Generator
         foreach ($dir as $fileinfo) {
             if (!$fileinfo->isDot()) {
                 $noExt = $this->removeExtension($fileinfo->getFilename());
+                // Ignore non *.php files (ex.: .gitignore, vim swap files etc.)
+                if (pathinfo($fileinfo->getFileName())['extension'] !== 'php') {
+                    continue;
+                }
                 $tmp = include($path . '/' . $fileinfo->getFilename());
 
                 $data[$noExt] = $this->adjustArray($tmp);


### PR DESCRIPTION
For example .gitignore and vim swap files are causing errors on generate.
This fixes all the errors.