### PR TITLE
Support dir nesting (and further minor tweaks)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     ],
     "require": {
         "php": ">=5.5.0",
-        "laravel/framework": "~5.1"
+        "illuminate/console": "~5.1.0|~5.2.0|~5.3.0",
+        "illuminate/support": "~5.1.0|~5.2.0|~5.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.7"

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -42,10 +42,20 @@ class Generator
 
         $dir = new DirectoryIterator($path);
         foreach ($dir as $fileinfo) {
-            if (!$fileinfo->isDot()) {
+            // Do not mess with dotfiles at all.
+            if ($fileinfo->isDot()) {
+                continue;
+            }
+
+            // Check if the "file" is a subdirectory which has to be scanned.
+            if ($fileinfo->isDir()) {
+                // Recursivley iterate through subdirs, until everything was allocated.
+                $data = $this->allocateLocaleArray($path . '/' . $fileinfo->getFilename());
+            } else {
                 $noExt = $this->removeExtension($fileinfo->getFilename());
+
                 // Ignore non *.php files (ex.: .gitignore, vim swap files etc.)
-                if (pathinfo($fileinfo->getFileName())['extension'] !== 'php') {
+                if (pathinfo($fileinfo->getFileName(), PATHINFO_EXTENSION) !== 'php') {
                     continue;
                 }
                 $tmp = include($path . '/' . $fileinfo->getFilename());

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -50,7 +50,8 @@ class Generator
             // Check if the "file" is a subdirectory which has to be scanned.
             if ($fileinfo->isDir()) {
                 // Recursivley iterate through subdirs, until everything was allocated.
-                $data = $this->allocateLocaleArray($path . '/' . $fileinfo->getFilename());
+                $data[$fileinfo->getFilename()] =
+                    $this->allocateLocaleArray($path . '/' . $fileinfo->getFilename());
             } else {
                 $noExt = $this->removeExtension($fileinfo->getFilename());
 

--- a/src/GeneratorProvider.php
+++ b/src/GeneratorProvider.php
@@ -30,6 +30,10 @@ class GeneratorProvider extends ServiceProvider
             __DIR__.'/config/vue-i18n-generator.php' => config_path('vue-i18n-generator.php'),
         ]);
 
+         $this->mergeConfigFrom(
+            __DIR__.'/config/vue-i18n-generator.php',
+            'vue-i18n-generator'
+        );
     }
 
     /**


### PR DESCRIPTION
Hi there, as issue #8 mentions, currently there is a problem with this package, if your language directory contains subdirs.

This pull requests should fix this issue. All unit tests remained green for me. Furthermore there are some additional tweaks, namely:

* Removed the dependency on `laravel/framework` and added `illuminate/console`, `illuminate/support ` respectively (also supporting versions 5.2 and 5.3)
* Merging the scaffold config of this component into the runtime application config as a default, as those values are fine in most cases (removing the need to publish configs)

greetings voydz