### PR TITLE
share() method has depreciated in Laravel 5.4

### DIFF
--- a/src/GeneratorProvider.php
+++ b/src/GeneratorProvider.php
@@ -18,7 +18,7 @@ class GeneratorProvider extends ServiceProvider
      */
     public function boot()
     {
-        $this->app[ 'vue-i18n.generate' ] = $this->app->share(function () {
+        $this->app->singleton('vue-i18n.generate', function () {
             return new Commands\GenerateInclude;
         });
 


### PR DESCRIPTION
Use singleton() for service binding as Laravel 5.4 depreciated share() method.