### PR TITLE
Add support for JSON translation files

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -43,8 +43,8 @@ class Generator
                 if (pathinfo($fileName, PATHINFO_EXTENSION) !== 'json') {
                     continue;
                 }
-                $tmp = json_decode(file_get_contents($fileinfo->getRealPath()));
-                if (gettype($tmp) !== "object") {
+                $tmp = (array) json_decode(file_get_contents($fileinfo->getRealPath()));
+                if (gettype($tmp) !== "array") {
                     throw new Exception('Unexpected data while processing '.$fileName);
                     continue;
                 }


### PR DESCRIPTION
This PR adds support for [JSON translation files](https://laravel.com/docs/5.4/localization#defining-translation-strings) which is new in Laravel 5.4.