### PR TITLE
Individual locales files

### DIFF
--- a/src/Commands/GenerateInclude.php
+++ b/src/Commands/GenerateInclude.php
@@ -11,7 +11,7 @@ class GenerateInclude extends Command
      *
      * @var string
      */
-    protected $signature = 'vue-i18n:generate {--umd}';
+    protected $signature = 'vue-i18n:generate {--umd} {--multi}';
 
     /**
      * The console command description.
@@ -30,11 +30,20 @@ class GenerateInclude extends Command
 
         $umd = $this->option('umd');
 
+        $multipleFiles = $this->option('multi');
+
+        if ($multipleFiles) {
+            $files = (new Generator)
+                ->generateMultiple($root, $umd);
+            echo "Written to :" . PHP_EOL . $files . PHP_EOL;
+            exit();
+        }
+
         $data = (new Generator)
             ->generateFromPath($root, $umd);
 
-        $jsFile = base_path() . config('vue-i18n-generator.jsFile');
 
+        $jsFile = base_path() . config('vue-i18n-generator.jsFile');
         file_put_contents($jsFile, $data);
 
         echo "Written to " . $jsFile . PHP_EOL;

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -2,6 +2,7 @@
 
 use DirectoryIterator;
 use Exception;
+use App;
 
 class Generator
 {
@@ -80,6 +81,7 @@ class Generator
             ) {
                 $noExt = $this->removeExtension($fileinfo->getFilename());
                 if (!in_array($noExt, $this->availableLocales)) {
+                    App::setLocale($noExt);
                     $this->availableLocales[] = $noExt;
                 }
                 if ($fileinfo->isDir()) {

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -163,15 +163,19 @@ class Generator
                     continue;
                 }
 
-                $root = realpath(base_path() . config('vue-i18n-generator.langPath') . '/' . $lastLocale);
-                $filePath = $this->removeExtension(str_replace('\\', '_', ltrim(str_replace($root, '', realpath($fileName)), '\\')));
+
                 $tmp = include($fileName);
 
                 if (gettype($tmp) !== "array") {
                     throw new Exception('Unexpected data while processing ' . $fileName);
                     continue;
                 }
-                $this->filesToCreate[$filePath][$lastLocale] = $this->adjustArray($tmp);
+                if($lastLocale !== false){
+                    $root = realpath(base_path() . config('vue-i18n-generator.langPath') . '/' . $lastLocale);
+                    $filePath = $this->removeExtension(str_replace('\\', '_', ltrim(str_replace($root, '', realpath($fileName)), '\\')));
+                    $this->filesToCreate[$filePath][$lastLocale] = $this->adjustArray($tmp);
+                }
+
                 $data[$noExt] = $this->adjustArray($tmp);
 
             }
@@ -183,8 +187,7 @@ class Generator
      * @param array $arr
      * @return array
      */
-    private
-    function adjustArray(array $arr)
+    private function adjustArray(array $arr)
     {
         $res = [];
         foreach ($arr as $key => $val) {
@@ -203,8 +206,7 @@ class Generator
      * @param string $s
      * @return string
      */
-    private
-    function adjustString($s)
+    private function adjustString($s)
     {
         if (!is_string($s)) {
             return $s;
@@ -224,8 +226,7 @@ class Generator
      * @param string $filename
      * @return string
      */
-    private
-    function removeExtension($filename)
+    private function removeExtension($filename)
     {
         $pos = mb_strrpos($filename, '.');
         if ($pos === false) {
@@ -240,8 +241,7 @@ class Generator
      * @param string $body
      * @return string
      */
-    private
-    function getUMDModule($body)
+    private function getUMDModule($body)
     {
         $js = <<<HEREDOC
 (function (global, factory) {
@@ -260,8 +260,7 @@ HEREDOC;
      * @param string $body
      * @return string
      */
-    private
-    function getES6Module($body)
+    private function getES6Module($body)
     {
         return "export default {$body}";
     }

--- a/src/config/vue-i18n-generator.php
+++ b/src/config/vue-i18n-generator.php
@@ -23,6 +23,6 @@ return [
     | Note: the path will be prepended to point to the App directory.
     |
     */
-
+    'jsPath' => '/resources/assets/js/langs/',
     'jsFile' => '/resources/assets/js/vue-i18n-locales.generated.js'
 ];


### PR DESCRIPTION
Added Option to create Multiple Files using --multi flag so you can have language files dependent of its view 
Notice I use a independent file for errors and words to prevent duplicates on my language but still have a single component js to load , I change the Locale getting the $noExt  like this 

```php
App::setLocale($noExt); 
```
en/login.php and es/login.php

```php
return [

    /*
    |--------------------------------------------------------------------------
    | Login Language Lines
    |--------------------------------------------------------------------------
    | Login form
    |
    */

    'email' => [
        'label' => Lang::get('words.email'),
        'error' => Lang::get('errors.please_enter_valid',['label' => Lang::get('words.email')]),
    ],
 ];
```

login.js
```js
"en": {
        "email": {
            "label": "Email Address",
            "error": "Please enter a valid Email Address",
        },
      :
    },
    "es": {
        "email": {
            "label": "Correo Electronico",
            "error": "Por favor inserta un Correo Electronico correcto",
        },
    } 
```

and the final js can be imported via component 
login.vue
```vue
<template><label for="email">{{ $t('email.label') }}</label></template>
<script type="text/javascript">
  import loginLang from '../../langs/login';
export default {
data() {
      return {
      };
    },
    i18n: { // `i18n` option

      messages: loginLang ,
    },
</script>
}
```