### PR TITLE
Named translation fix for JSON files

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -126,12 +126,12 @@ class Generator
         if (pathinfo($path, PATHINFO_EXTENSION) !== 'json') {
             return null;
         }
-        $tmp = (array)json_decode(file_get_contents($path));
+        $tmp = (array)json_decode(file_get_contents($path), true);
         if (gettype($tmp) !== "array") {
             throw new Exception('Unexpected data while processing ' . $path);
         }
 
-        return $tmp;
+        return $this->adjustArray($tmp);
     }
 
     /**


### PR DESCRIPTION
Placeholders JSON language files were not converted from `:placeholder` to `{placeholder}` as in PHP