### PR TITLE
Add format option and JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,11 +139,18 @@ var app = new Vue({
 });
 ```
 
-## UMD module
+## Output Formats
 
-If you want to generate an UMD style export, you can with the `--umd` option
+You can specify the output formats from `es6`, `umd`, or `json` with the `--format` option. (defaults to `es6`)
+
 ```
-php artisan vue-i18n:generate --umd
+php artisan vue-i18n:generate --format {es6,umd,json}
+```
+
+### Use case example for UMD module
+
+```
+php artisan vue-i18n:generate --format umd
 ```
 An UMD module can be imported into the browser, build system, node and etc. 
 

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -30,12 +30,12 @@ class Generator
 
     /**
      * @param string $path
-     * @param boolean $umd
+     * @param string $format
      * @param boolean $withVendor
      * @return string
      * @throws Exception
      */
-    public function generateFromPath($path, $umd = null, $withVendor = false, $langFiles = [])
+    public function generateFromPath($path, $format = 'es6', $withVendor = false, $langFiles = [])
     {
         if (!is_dir($path)) {
             throw new Exception('Directory not found: ' . $path);
@@ -83,27 +83,31 @@ class Generator
         $locales = $this->adjustVendor($locales);
 
         $jsonLocales = json_encode($locales, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . PHP_EOL;
-        
+
         if(json_last_error() !== JSON_ERROR_NONE)
         {
             throw new Exception('Could not generate JSON, error code '.json_last_error());
         }
-        
-        if (!$umd) {
+
+        // formats other than 'es6' and 'umd' will become plain JSON
+        if ($format === 'es6') {
             $jsBody = $this->getES6Module($jsonLocales);
-        } else {
+        } elseif($format === 'umd') {
             $jsBody = $this->getUMDModule($jsonLocales);
+        } else {
+            $jsBody = $jsonLocales;
         }
+
         return $jsBody;
     }
 
     /**
      * @param string $path
-     * @param boolean $umd
+     * @param string $format
      * @return string
      * @throws Exception
      */
-    public function generateMultiple($path, $umd = null)
+    public function generateMultiple($path, $format = 'es6')
     {
         if (!is_dir($path)) {
             throw new Exception('Directory not found: ' . $path);
@@ -149,10 +153,12 @@ class Generator
             {
                 throw new Exception('Could not generate JSON, error code '.json_last_error());
             }
-            if (!$umd) {
+            if ($format === 'es6') {
                 $jsBody = $this->getES6Module($jsonLocales);
-            } else {
+            } elseif($format === 'umd') {
                 $jsBody = $this->getUMDModule($jsonLocales);
+            } else {
+                $jsBody = $jsonLocales;
             }
 
             if (!is_dir(dirname($fileToCreate))) {
@@ -270,9 +276,9 @@ class Generator
 
     /**
      * Adjus vendor index placement.
-     * 
+     *
      * @param array $locales
-     * 
+     *
      * @return array
      */
     private function adjustVendor($locales)

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -86,6 +86,143 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
         $this->destroyLocaleFilesFrom($arr, $root);
     }
 
+    function testBasicES6Format()
+    {
+        $format = 'es6';
+
+        $arr = [
+            'en' => [
+                'help' => [
+                    'yes' => 'yes',
+                    'no' => 'no',
+                ]
+            ],
+            'sv' => [
+                'help' => [
+                    'yes' => 'ja',
+                    'no' => 'nej',
+                ]
+            ]
+        ];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+        $this->assertEquals(
+            'export default {' . PHP_EOL
+            . '    "en": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "yes",' . PHP_EOL
+            . '            "no": "no"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    },' . PHP_EOL
+            . '    "sv": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "ja",' . PHP_EOL
+            . '            "no": "nej"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL,
+            (new Generator([]))->generateFromPath($root, $format));
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
+    function testBasicWithUMDFormat()
+    {
+        $format = 'umd';
+        $arr = [
+            'en' => [
+                'help' => [
+                    'yes' => 'yes',
+                    'no' => 'no',
+                ]
+            ],
+            'sv' => [
+                'help' => [
+                    'yes' => 'ja',
+                    'no' => 'nej',
+                ]
+            ]
+        ];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+        $this->assertEquals(
+            '(function (global, factory) {' . PHP_EOL
+            . '    typeof exports === \'object\' && typeof module !== \'undefined\' ? module.exports = factory() :' . PHP_EOL
+            . '        typeof define === \'function\' && define.amd ? define(factory) :' . PHP_EOL
+            . '            (global.vuei18nLocales = factory());' . PHP_EOL
+            . '}(this, (function () { \'use strict\';' . PHP_EOL
+            . '    return {' . PHP_EOL
+            . '    "en": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "yes",' . PHP_EOL
+            . '            "no": "no"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    },' . PHP_EOL
+            . '    "sv": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "ja",' . PHP_EOL
+            . '            "no": "nej"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL
+            . PHP_EOL
+            . '})));',
+            (new Generator([]))->generateFromPath($root, $format));
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
+    function testBasicWithJSONFormat()
+    {
+        $format = 'json';
+        $arr = [
+            'en' => [
+                'help' => [
+                    'yes' => 'yes',
+                    'no' => 'no',
+                ]
+            ],
+            'sv' => [
+                'help' => [
+                    'yes' => 'ja',
+                    'no' => 'nej',
+                ]
+            ]
+        ];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+        $this->assertEquals(
+            '{' . PHP_EOL
+            . '    "en": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "yes",' . PHP_EOL
+            . '            "no": "no"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    },' . PHP_EOL
+            . '    "sv": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "ja",' . PHP_EOL
+            . '            "no": "nej"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL,
+            (new Generator([]))->generateFromPath($root, $format));
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
+    function testInvalidFormat()
+    {
+        $format = 'es5';
+        $arr = [];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+        try {
+            (new Generator([]))->generateFromPath($root, $format);
+        } catch(RuntimeException $e) {
+            $this->assertEquals('Invalid format passed: ' . $format, $e->getMessage());
+
+        }
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
     function testBasicWithTranslationString()
     {
         $arr = [
@@ -171,7 +308,7 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
             . '        }' . PHP_EOL
             . '    }' . PHP_EOL
             . '}' . PHP_EOL,
-            (new Generator([]))->generateFromPath($root, false, true));
+            (new Generator([]))->generateFromPath($root, 'es6', true));
 
         $this->destroyLocaleFilesFrom($arr, $root);
     }


### PR DESCRIPTION
## Description
This change allows for a new --format option. Available options are `es6`, `umd` and `json`. The option defaults to `es6`.

Signed-off-by: Ken Fukuyama <ken.fukuyama@cydas.com>

## Motivation and Context
The related issue is #73 .

## How Has This Been Tested?

With the structure below:

```
resources/lang
├── en
│   ├── help.php
│   └── plural.php
├── sv
│   ├── help.php
│   └── plural.php
└── vendor
    └── test-vendor
        ├── en
        │   └── test-lang.php
        └── sv
            └── test-lang.php
```

### no format (defaults to `es6`)
```
 php artisan vue-i18n:generate
```

```js
export default {
    "en": {
        "plural": {
            "one": "There is one apple|There are many apples",
            "two": "There is one apple | There are many apples",
            "five": {
                "three": "There is one apple    | There are many apples",
                "four": "There is one apple |     There are many apples"
            }
        },
        "help": {
            "yes": "see {link} and {lonk}",
            "no": {
                "one": "see {link}"
            }
        }
    },
    "sv": {
        "plural": {
            "one": "Det finns ett äpple|Det finns många äpple",
            "two": "Det finns ett äpple | Det finns många äpple",
            "five": {
                "three": "Det finns ett äpple    | Det finns många äpple",
                "four": "Det finns ett äpple |     Det finns många äpple"
            }
        },
        "help": {
            "yes": "se {link} och {lonk}",
            "no": {
                "one": "se {link}"
            }
        }
    }
}
```

### es6 format
```
 php artisan vue-i18n:generate --format es6
```

The result is the same as above since it defaults to es6.

### umd format
```
 php artisan vue-i18n:generate --format umd
```

```js
(function (global, factory) {
    typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
        typeof define === 'function' && define.amd ? define(factory) :
            (global.vuei18nLocales = factory());
}(this, (function () { 'use strict';
    return {
    "en": {
        "plural": {
            "one": "There is one apple|There are many apples",
            "two": "There is one apple | There are many apples",
            "five": {
                "three": "There is one apple    | There are many apples",
                "four": "There is one apple |     There are many apples"
            }
        },
        "help": {
            "yes": "see {link} and {lonk}",
            "no": {
                "one": "see {link}"
            }
        }
    },
    "sv": {
        "plural": {
            "one": "Det finns ett äpple|Det finns många äpple",
            "two": "Det finns ett äpple | Det finns många äpple",
            "five": {
                "three": "Det finns ett äpple    | Det finns många äpple",
                "four": "Det finns ett äpple |     Det finns många äpple"
            }
        },
        "help": {
            "yes": "se {link} och {lonk}",
            "no": {
                "one": "se {link}"
            }
        }
    }
}

})));
```

### backwards compatibility with `--umd`
```
 php artisan vue-i18n:generate --umd
```

Same result as above.

### json format
```
 php artisan vue-i18n:generate --format json
```

```json
{
    "en": {
        "plural": {
            "one": "There is one apple|There are many apples",
            "two": "There is one apple | There are many apples",
            "five": {
                "three": "There is one apple    | There are many apples",
                "four": "There is one apple |     There are many apples"
            }
        },
        "help": {
            "yes": "see {link} and {lonk}",
            "no": {
                "one": "see {link}"
            }
        }
    },
    "sv": {
        "plural": {
            "one": "Det finns ett äpple|Det finns många äpple",
            "two": "Det finns ett äpple | Det finns många äpple",
            "five": {
                "three": "Det finns ett äpple    | Det finns många äpple",
                "four": "Det finns ett äpple |     Det finns många äpple"
            }
        },
        "help": {
            "yes": "se {link} och {lonk}",
            "no": {
                "one": "se {link}"
            }
        }
    }
}
```

## Types of changes
This is a new feature and has backwards compatibility with the `--umd` option.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.