### PR TITLE
Remove assets from path folder in config file

### DIFF
--- a/src/config/vue-i18n-generator.php
+++ b/src/config/vue-i18n-generator.php
@@ -55,8 +55,8 @@ return [
     | Note: the path will be prepended to point to the App directory.
     |
     */
-    'jsPath' => '/resources/assets/js/langs/',
-    'jsFile' => '/resources/assets/js/vue-i18n-locales.generated.js',
+    'jsPath' => '/resources/js/langs/',
+    'jsFile' => '/resources/js/vue-i18n-locales.generated.js',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
For new Laravel 5.7 applications, the assets directory that contains the scripts and styles has been flattened into the resources directory. 

@see https://laravel.com/docs/5.7/upgrade