### PR TITLE
Adding escape character

### DIFF
--- a/src/config/vue-i18n-generator.php
+++ b/src/config/vue-i18n-generator.php
@@ -79,4 +79,15 @@ return [
     |
     */
     'showOutputMessages' => false,
+
+    /*
+   |--------------------------------------------------------------------------
+   | Escape character
+   |--------------------------------------------------------------------------
+   |
+   | Allows to escape translations strings that should not be treated as a
+   | variable
+   |
+   */
+    'escape_char' => '!',
 ];

--- a/tests/GenerateTest.php
+++ b/tests/GenerateTest.php
@@ -246,6 +246,31 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
         $this->destroyLocaleFilesFrom($arr, $root);
     }
 
+    function testBasicWithEscapedTranslationString()
+    {
+        $arr = [
+            'en' => [
+                'main' => [
+                    'hello :name' => 'Hello :name',
+                    'time test 10!:00' => 'Time test 10!:00',
+                ]
+            ],
+        ];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+        $this->assertEquals(
+            'export default {' . PHP_EOL
+            . '    "en": {' . PHP_EOL
+            . '        "main": {' . PHP_EOL
+            . '            "hello {name}": "Hello {name}",' . PHP_EOL
+            . '            "time test 10:00": "Time test 10:00"' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL,
+            (new Generator([]))->generateFromPath($root));
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
     function testBasicWithVendor()
     {
         $arr = [
@@ -375,6 +400,62 @@ class GenerateTest extends \PHPUnit_Framework_TestCase
             . '            "no": {' . PHP_EOL
             . '                "one": "see {link}"' . PHP_EOL
             . '            }' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL,
+            (new Generator([]))->generateFromPath($root));
+
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
+    function testNamedWithEscaped()
+    {
+        $arr = [
+            'en' => [
+                'help' => [
+                    'yes' => 'see :link y :lonk at 08!:00',
+                    'no' => [
+                        'one' => 'see :link',
+                    ]
+                ]
+            ]
+        ];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+
+        $this->assertEquals(
+            'export default {' . PHP_EOL
+            . '    "en": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "yes": "see {link} y {lonk} at 08:00",' . PHP_EOL
+            . '            "no": {' . PHP_EOL
+            . '                "one": "see {link}"' . PHP_EOL
+            . '            }' . PHP_EOL
+            . '        }' . PHP_EOL
+            . '    }' . PHP_EOL
+            . '}' . PHP_EOL,
+            (new Generator([]))->generateFromPath($root));
+
+        $this->destroyLocaleFilesFrom($arr, $root);
+    }
+
+    function testEscapedEscapeCharacter()
+    {
+        $arr = [
+            'en' => [
+                'help' => [
+                    'test escaped' => 'escaped escape char not !!:touched',
+                ]
+            ]
+        ];
+
+        $root = $this->generateLocaleFilesFrom($arr);
+
+        $this->assertEquals(
+            'export default {' . PHP_EOL
+            . '    "en": {' . PHP_EOL
+            . '        "help": {' . PHP_EOL
+            . '            "test escaped": "escaped escape char not !:touched"' . PHP_EOL
             . '        }' . PHP_EOL
             . '    }' . PHP_EOL
             . '}' . PHP_EOL,


### PR DESCRIPTION
Adds an escape character to allow escaping translation strings that contain the Laravel :link keyword.

This should fix #69 and allow to have strings in the translation that contains a colon but should not be treated in the typical Laravel way. 

I chose "!" as a default character, because it does not have a special meaning in PHP and the combination of "!:" should be uncommon. But the escape character itself can the escaped. Furthermore, it can be changed in the config. 

The impact for most users should be minimal, but since it adds the escape sequence and there is a possibility that someone has "!:foo" in the translations and now expects "!{foo}" I would consider that a breaking change. 
