### PR TITLE
Only handle arrays as arrays in translation files

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -3,6 +3,7 @@
 use DirectoryIterator;
 use Exception;
 use App;
+use Traversable;
 
 class Generator
 {
@@ -251,7 +252,7 @@ class Generator
         foreach ($arr as $key => $val) {
             $key = $this->removeEscapeCharacter($this->adjustString($key));
 
-            if (is_iterable($val)) {
+            if (is_array($val)) {
                 $res[$key] = $this->adjustArray($val);
             } else {
                 $res[$key] = $this->removeEscapeCharacter($this->adjustString($val));

--- a/src/Generator.php
+++ b/src/Generator.php
@@ -251,10 +251,10 @@ class Generator
         foreach ($arr as $key => $val) {
             $key = $this->removeEscapeCharacter($this->adjustString($key));
 
-            if (is_string($val)) {
-                $res[$key] = $this->removeEscapeCharacter($this->adjustString($val));
-            } else {
+            if (is_iterable($val)) {
                 $res[$key] = $this->adjustArray($val);
+            } else {
+                $res[$key] = $this->removeEscapeCharacter($this->adjustString($val));
             }
         }
         return $res;


### PR DESCRIPTION
One of our translation file contained a line was a number, this broke the generator. While typically only strings should be present in the translation this pull request makes sure that an other type does not break the generator.