### PR TITLE
Fix locale association

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -208,7 +208,7 @@ class Generator
     {
         $data = [];
         $dir = new DirectoryIterator($path);
-        $lastLocale = last($this->availableLocales);
+
         foreach ($dir as $fileinfo) {
             // Do not mess with dotfiles at all.
             if ($fileinfo->isDot()) {
@@ -222,6 +222,7 @@ class Generator
             } else {
                 $noExt = $this->removeExtension($fileinfo->getFilename());
                 $fileName = $path . DIRECTORY_SEPARATOR . $fileinfo->getFilename();
+                $lastLocale = basename(dirname($fileName));
 
                 // Ignore non *.php files (ex.: .gitignore, vim swap files etc.)
                 if (pathinfo($fileName, PATHINFO_EXTENSION) !== 'php') {


### PR DESCRIPTION
When using multiple locales with e.g. a_locale.json files and folders with php files a_locale/errors.php then the translations were mixed in the wrong files because of a wrong "lastLocale" variable. The locale will now be determined by the given file path. That results to the correct association.

In my example translations from de and en had been merged to fr.js. With this patch it correct.

E.g. with:

resources/lang/{de|fr|en|pl|es}.json AND
resources/lang/{de|fr|en|pl|es}/errors.php
resources/lang/{de|fr|en|pl|es}/fields.php etc.

and Command:

php artisan vue-i18n:generate --multi-locales